### PR TITLE
Add console to inittab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ADD rootfs.tar.gz /
 
 ADD root/ /
 
+RUN echo 'console::askfirst:/usr/libexec/login.sh' >> /etc/inittab
+
 EXPOSE 80 443 22
 
 USER root


### PR DESCRIPTION
allows to enter a shell after starting the container without it is only posible to access a shell on tty1 via lxc-console.